### PR TITLE
Fix drop-in simulation bug

### DIFF
--- a/R/genDataset.R
+++ b/R/genDataset.R
@@ -141,7 +141,7 @@ genDataset = function(nC,popFreq,mu=1000,sigma=0.1,sorted=FALSE,threshT=50,refDa
     
     #Simulate drop-in
     pos <- ceiling(log(1e-16)/log(prC0)) #get number of possible dropins
-    if(length(pos)>1) { #dropin done last
+    if(pos>1) { #dropin done last
      prCvec <- c(1-prC0/(1-prC0),prC0^(1:pos))
      nDI <- sample(0:pos,size=1,prob=prCvec,replace=TRUE) #number of dropin
      if(nDI>0) {


### PR DESCRIPTION
Hi!!

Current version of the genDataset() function does not produce any drop-in. This is because variable "pos" is always one element, as it originates from "prC0", which is always one element (because the code loops over loci one by one). This small change should hopefully fix the issue : )

All the best!
Kai Budrikas